### PR TITLE
Allows Experiment#in? to be called on removed experiments

### DIFF
--- a/app/models/experimental/experiment.rb
+++ b/app/models/experimental/experiment.rb
@@ -58,7 +58,7 @@ module Experimental
     end
 
     def in?(subject)
-      raise "Experiment is removed and should not be called" if removed?
+      return false if removed?
       population_filter.in?(subject, self)
     end
 

--- a/spec/models/experimental/experiment_spec.rb
+++ b/spec/models/experimental/experiment_spec.rb
@@ -509,4 +509,21 @@ describe Experimental::Experiment do
       end
     end
   end
+
+  describe "#in?" do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:experiment) { FactoryGirl.create(:experiment) }
+
+    context "when the experiment has been removed" do
+      before { experiment.stub(:removed?).and_return(true) }
+
+      it "does not raise an exception" do
+        expect { experiment.in?(user) }.to_not raise_error
+      end
+
+      it "is false" do
+        experiment.in?(user).should be_false
+      end
+    end
+  end
 end


### PR DESCRIPTION
- No longer raises an exception
  - Returns false
  - We have a new requirement to return experiment information for
    possibly-removed experiments to mobile devices who can be running
    ancient versions from our API. The old behavior made obtaining
    historical information difficult.
