### PR TITLE
Fix syncing of deleted attributes for existing tasks.

### DIFF
--- a/app/models/experimental/loader.rb
+++ b/app/models/experimental/loader.rb
@@ -12,7 +12,8 @@ module Experimental
 
         #new/active
         experiments.in_code.each do |exp|
-          name = exp.with_indifferent_access[:name]
+          exp = exp.with_indifferent_access
+          name = exp[:name]
           puts "\tUpdating #{name} ..." if verbose
 
           exp = whitelisted_attrs(exp)
@@ -55,9 +56,11 @@ module Experimental
       end
 
       def whitelisted_attrs(exp)
-        exp.
-          select { |k, v| @@whitelisted_attributes.include?(k.to_sym) }.
-          with_indifferent_access
+        attributes = {}
+        @@whitelisted_attributes.each do |name|
+          attributes[name.to_sym] = exp[name]
+        end
+        attributes
       end
     end
   end

--- a/spec/models/experimental/loader_spec.rb
+++ b/spec/models/experimental/loader_spec.rb
@@ -65,7 +65,7 @@ describe Experimental::Loader do
         removed: [
           { name: :removed_exp, num_buckets: 2, notes: "0 is default, 1 is new" }
       ]
-    }.with_indifferent_access
+    }
   }
 
   let(:update_attrs) { { without_protection: true } }


### PR DESCRIPTION
Can't think of a good way to test this sadly. Would be good if the loader took
configuration as an argument, and did not have the YAML read hardcoded into it.
