### PR TITLE
Experimental::Experiment#restart bugfix

### DIFF
--- a/app/models/experimental/experiment.rb
+++ b/app/models/experimental/experiment.rb
@@ -67,6 +67,7 @@ module Experimental
       self.winning_bucket = nil
       self.start_date = Time.now
       self.end_date = nil
+      self.removed_at = nil
 
       save
     end

--- a/spec/models/experimental/experiment_spec.rb
+++ b/spec/models/experimental/experiment_spec.rb
@@ -360,6 +360,12 @@ describe Experimental::Experiment do
         experiment.restart
         experiment.reload.should_not be_ended
       end
+
+      it "sets the removed at to nil" do
+        experiment.remove
+        experiment.restart
+        experiment.should_not be_removed
+      end
     end
 
     context "when given an experiment that has not already ended" do


### PR DESCRIPTION
- In order for an experiment to respond `true` to #active? the
  removed_at timestamp needs to be set to nil on restart
