### PR TITLE
Add support for unstarted experiments.

### DIFF
--- a/lib/experimental/loader.rb
+++ b/lib/experimental/loader.rb
@@ -14,10 +14,17 @@ module Experimental
       Experimental::Experiment.transaction do
         active = Experimental.experiment_data.map do |name, attributes|
           experiment = Experimental::Experiment.find_or_initialize_by_name(name)
-          logger.info "  * #{experiment.id ? 'updating' : 'creating'} #{name}"
+
+          unstarted = attributes.delete('unstarted')
           defaults = {'num_buckets' => nil, 'notes' => nil, 'population' => nil}
           experiment.assign_attributes(defaults.merge(attributes))
-          experiment.start_date ||= Time.now
+          if unstarted
+            experiment.start_date = nil
+          else
+            experiment.start_date ||= Time.current
+          end
+
+          logger.info "  * #{experiment.id ? 'updating' : 'creating'} #{name}"
           experiment.tap(&:save!)
         end
 

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -3,9 +3,7 @@ FactoryGirl.define do
     name "test"
     population 'default'
     num_buckets 2
-    start_date nil
-    end_date nil
-    removed_at nil
+    start_date { 2.days.ago }
 
     factory :random_experiment do
       sequence(:name) { |n| "test#{n}" }
@@ -22,12 +20,33 @@ FactoryGirl.define do
       winning_bucket 0
     end
 
+    trait :started do
+      # default, but can be stated explicitly
+    end
+
+    trait :unstarted do
+      start_date nil
+    end
+
+    trait :will_start do
+      start_date { 1.days.from_now }
+    end
+
+    trait :will_end do
+      end_date { 2.day.from_now }
+    end
+
+    trait :ended do
+      started
+      end_date { 1.day.ago }
+      winning_bucket 0
+    end
+
     trait :removed do
       removed_at { Time.now }
     end
   end
 
   factory :user do
-
   end
 end


### PR DESCRIPTION
An experiment is considered unstarted if it has no start_date set. Such an
experiment will return nil for everyone's bucket, as if it had a population
filter that included no users.

The loader will leave an experiment unstarted if an experiment has an
"unstarted: true" attribute set.
